### PR TITLE
btc: make keypath optional for script registrations

### DIFF
--- a/examples/btc_miniscript.rs
+++ b/examples/btc_miniscript.rs
@@ -60,7 +60,7 @@ async fn main() {
     // Register policy if not already registered. This must be done before any receive address is
     // created or any transaction is signed.
     let is_registered = paired_bitbox
-        .btc_is_script_config_registered(coin, &policy_config, &keypath_account)
+        .btc_is_script_config_registered(coin, &policy_config, None)
         .await
         .unwrap();
 
@@ -69,7 +69,7 @@ async fn main() {
             .btc_register_script_config(
                 coin,
                 &policy_config,
-                &keypath_account,
+                None,
                 pb::btc_register_script_config_request::XPubType::AutoXpubTpub,
                 None,
             )

--- a/sandbox/src/App.tsx
+++ b/sandbox/src/App.tsx
@@ -301,9 +301,9 @@ function BtcMiniscriptAddress({ bb02 }: ActionProps) {
       const scriptConfig = {
         policy: { policy, keys },
       };
-      const is_script_config_registered = await bb02.btcIsScriptConfigRegistered(coin, scriptConfig, keypath);
+      const is_script_config_registered = await bb02.btcIsScriptConfigRegistered(coin, scriptConfig, undefined);
       if (!is_script_config_registered) {
-        await bb02.btcRegisterScriptConfig(coin, scriptConfig, keypath, 'autoXpubTpub', undefined);
+        await bb02.btcRegisterScriptConfig(coin, scriptConfig, undefined, 'autoXpubTpub', undefined);
       }
       const address = await bb02.btcAddress(coin, keypath + "/0/10", scriptConfig, true);
       setResult(address);

--- a/src/btc.rs
+++ b/src/btc.rs
@@ -904,11 +904,14 @@ impl<R: Runtime> PairedBitBox<R> {
     /// Before a multisig or policy script config can be used to display receive addresses or sign
     /// transcations, it must be registered on the device. This function checks if the script config
     /// was already registered.
+    ///
+    /// `keypath_account` must be set if the script config is multisig, and can be `None` if it is a
+    /// policy.
     pub async fn btc_is_script_config_registered(
         &self,
         coin: pb::BtcCoin,
         script_config: &pb::BtcScriptConfig,
-        keypath_account: &Keypath,
+        keypath_account: Option<&Keypath>,
     ) -> Result<bool, Error> {
         match self
             .query_proto_btc(pb::btc_request::Request::IsScriptConfigRegistered(
@@ -916,7 +919,7 @@ impl<R: Runtime> PairedBitBox<R> {
                     registration: Some(pb::BtcScriptConfigRegistration {
                         coin: coin as _,
                         script_config: Some(script_config.clone()),
-                        keypath: keypath_account.to_vec(),
+                        keypath: keypath_account.map_or(vec![], |kp| kp.to_vec()),
                     }),
                 },
             ))
@@ -935,11 +938,15 @@ impl<R: Runtime> PairedBitBox<R> {
     /// If no name is provided, the user will be asked to enter it on the device instead.  If
     /// provided, it must be non-empty, smaller or equal to 30 chars, consist only of printable
     /// ASCII characters, and contain no whitespace other than spaces.
+    ///
+    ///
+    /// `keypath_account` must be set if the script config is multisig, and can be `None` if it is a
+    /// policy.
     pub async fn btc_register_script_config(
         &self,
         coin: pb::BtcCoin,
         script_config: &pb::BtcScriptConfig,
-        keypath_account: &Keypath,
+        keypath_account: Option<&Keypath>,
         xpub_type: pb::btc_register_script_config_request::XPubType,
         name: Option<&str>,
     ) -> Result<(), Error> {
@@ -949,7 +956,7 @@ impl<R: Runtime> PairedBitBox<R> {
                     registration: Some(pb::BtcScriptConfigRegistration {
                         coin: coin as _,
                         script_config: Some(script_config.clone()),
-                        keypath: keypath_account.to_vec(),
+                        keypath: keypath_account.map_or(vec![], |kp| kp.to_vec()),
                     }),
                     name: name.unwrap_or("").into(),
                     xpub_type: xpub_type as _,

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -165,14 +165,17 @@ impl PairedBitBox {
         &self,
         coin: types::TsBtcCoin,
         script_config: types::TsBtcScriptConfig,
-        keypath_account: types::TsKeypath,
+        keypath_account: Option<types::TsKeypath>,
     ) -> Result<bool, JavascriptError> {
         Ok(self
             .0
             .btc_is_script_config_registered(
                 coin.try_into()?,
                 &script_config.try_into()?,
-                &keypath_account.try_into()?,
+                keypath_account
+                    .map(|kp| kp.try_into())
+                    .transpose()?
+                    .as_ref(),
             )
             .await?)
     }
@@ -182,7 +185,7 @@ impl PairedBitBox {
         &self,
         coin: types::TsBtcCoin,
         script_config: types::TsBtcScriptConfig,
-        keypath_account: types::TsKeypath,
+        keypath_account: Option<types::TsKeypath>,
         xpub_type: types::TsBtcRegisterXPubType,
         name: Option<String>,
     ) -> Result<(), JavascriptError> {
@@ -191,7 +194,10 @@ impl PairedBitBox {
             .btc_register_script_config(
                 coin.try_into()?,
                 &script_config.try_into()?,
-                &keypath_account.try_into()?,
+                keypath_account
+                    .map(|kp| kp.try_into())
+                    .transpose()?
+                    .as_ref(),
                 xpub_type.try_into()?,
                 name.as_deref(),
             )


### PR DESCRIPTION
The keypath is unused when registering policies, as it is already present in the script config keys list. It is only required for multisig script registrations at the moment.