### PR TITLE
readme: improve setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,17 @@ produced from the Rust code using [Rust WASM](https://rustwasm.github.io/docs/bo
 The TypeScript library is experimental. Over time, it might replace the [bitbox02-api NPM
 package](https://www.npmjs.com/package/bitbox02-api).
 
-# Rust
+## Rust
 
-Install the protoc protobuf compiler, e.g. on Ubuntu:
+Install the protoc protobuf compiler:
+
+On Ubuntu:
 
     sudo apt-get install protobuf-compiler
+
+On MacOS:
+
+    brew install protobuf
 
 Check out [examples/connect.rs](examples/connect.rs) for an example.
 
@@ -27,13 +33,14 @@ To see the library docs:
 
     cargo doc --open
 
-# TypeScript
+## TypeScript
+If you also need a TypeScript library follow these steps as well.
 
 Install wasm-pack using:
 
     cargo install wasm-pack
 
-Install clang so libsecp256k1 can be cross compiled, e.g. on Ubuntu:
+If not yet installed, install clang so libsecp256k1 can be cross compiled, e.g. on Ubuntu:
 
     sudo apt-get install clang
 
@@ -43,6 +50,17 @@ The Rust library can be compiled to WASM package including TypeScript definition
 
 The output of this compilation will be in `./pkg`, which is a NPM package ready to be used.
 
+### M1 Macs 
+The default system clang installation currently cannot build wasm32 targets on M1 Macs. 
+Therefore a new clang compiler and archiver needs to be installed via:
+
+    brew install llvm
+
+In order to use that new clang compiler and archiver specify it when runing `make wasm`:
+
+    AR=/opt/homebrew/opt/llvm/bin/llvm-ar CC=/opt/homebrew/opt/llvm/bin/clang make wasm
+
+## Sandbox
 The [sandbox](sandbox/) subfolder contains a React project showcasing the TypeScript API. It
 has the library in `./pkg` as a depenency.
 


### PR DESCRIPTION
This commit restructures the README to make it easier to understand and adds additional information for M1 Mac users.