### PR TITLE
refactor communication by making the framing protocol configurable

### DIFF
--- a/sandbox/src/App.tsx
+++ b/sandbox/src/App.tsx
@@ -329,11 +329,22 @@ function App() {
   const [bb02, setBB02] = useState<bitbox.PairedBitBox>();
   const [pairingCode, setPairingCode] = useState<string>();
   const [err, setErr] = useState<bitbox.Error>();
-  const connectWebHID = async () => {
+  const connect = async (method: 'webHID' | 'bridge' | 'auto') => {
     setErr(undefined);
     try {
-      const b = await bitbox.bitbox02ConnectWebHID();
-      const pairing = await b.unlockAndPair();
+      let device: bitbox.BitBox;
+      switch (method) {
+        case 'webHID':
+          device = await bitbox.bitbox02ConnectWebHID();
+          break;
+        case 'bridge':
+          device = await bitbox.bitbox02ConnectBridge();
+          break;
+        case 'auto':
+          device = await bitbox.bitbox02ConnectAuto();
+          break;
+      }
+      const pairing = await device.unlockAndPair();
       setPairingCode(pairing.getPairingCode());
       setBB02(await pairing.waitConfirm());
       setPairingCode(undefined);
@@ -354,6 +365,11 @@ function App() {
   }
   if (pairingCode !== undefined) {
     return (
+    /* socket.onclose = event => {
+     *   if (this.onCloseCb) {
+     *     this.onCloseCb();
+     *   }
+     * }; */
       <>
         <h2>Pairing code</h2>
         <pre>
@@ -393,7 +409,9 @@ function App() {
   return (
     <>
       <h1>BitBox sandbox</h1>
-      <button onClick={connectWebHID}>Connect with WebHID</button>
+      <button onClick={() => connect('webHID')}>Connect using WebHID</button><br />
+      <button onClick={() => connect('bridge')}>Connect using BitBoxBridge</button><br />
+      <button onClick={() => connect('auto')}>Choose automatically</button>
     </>
   );
 }

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -32,14 +32,14 @@ pub trait ReadWrite {
     }
 }
 
-pub struct U2fCommunication {
+pub struct U2fHidCommunication {
     read_write: Box<dyn ReadWrite>,
     u2fhid: u2fframing::U2fHid,
 }
 
-impl U2fCommunication {
+impl U2fHidCommunication {
     pub fn from(read_write: Box<dyn ReadWrite>, cmd: u8) -> Self {
-        U2fCommunication {
+        U2fHidCommunication {
             read_write,
             u2fhid: u2fframing::U2fHid::new(cmd),
         }
@@ -47,7 +47,7 @@ impl U2fCommunication {
 }
 
 #[async_trait(?Send)]
-impl ReadWrite for U2fCommunication {
+impl ReadWrite for U2fHidCommunication {
     fn write(&self, msg: &[u8]) -> Result<usize, Error> {
         let mut buf = [0u8; u2fframing::MAX_LEN];
         let size = self.u2fhid.encode(msg, &mut buf).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,6 @@ pub use noise::{NoiseConfig, NoiseConfigNoCache};
 
 use self::communication::HwwCommunication;
 
-const FIRMWARE_CMD: u8 = 0x80 + 0x40 + 0x01;
-
 const OP_I_CAN_HAS_HANDSHAEK: u8 = b'h';
 const OP_HER_COMEZ_TEH_HANDSHAEK: u8 = b'H';
 const OP_I_CAN_HAS_PAIRIN_VERIFICASHUN: u8 = b'v';
@@ -72,9 +70,8 @@ impl<R: Runtime> BitBox<R> {
         device: Box<dyn communication::ReadWrite>,
         noise_config: Box<dyn NoiseConfig>,
     ) -> Result<BitBox<R>, Error> {
-        let u2f_communication = communication::U2fCommunication::from(device, FIRMWARE_CMD);
         Ok(BitBox {
-            communication: HwwCommunication::from(u2f_communication).await?,
+            communication: HwwCommunication::from(device).await?,
             noise_config,
         })
     }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use thiserror::Error;
 
 use super::communication::{
-    Error as CommuincationError, ReadWrite, U2fCommunication, FIRMWARE_CMD,
+    Error as CommuincationError, ReadWrite, U2fHidCommunication, FIRMWARE_CMD,
 };
 
 /// The hid product string of the multi edition firmware.
@@ -53,7 +53,7 @@ pub fn get_any_bitbox02() -> Result<Box<dyn ReadWrite>, UsbError> {
     for device_info in api.device_list() {
         if is_bitbox02(device_info) {
             let device = Box::new(device_info.open_device(&api)?);
-            let communication = Box::new(U2fCommunication::from(device, FIRMWARE_CMD));
+            let communication = Box::new(U2fHidCommunication::from(device, FIRMWARE_CMD));
             return Ok(communication);
         }
     }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use thiserror::Error;
 
 use super::communication::{
-    Error as CommuincationError, ReadWrite, U2fHidCommunication, FIRMWARE_CMD,
+    Error as CommunicationError, ReadWrite, U2fHidCommunication, FIRMWARE_CMD,
 };
 
 /// The hid product string of the multi edition firmware.
@@ -13,15 +13,15 @@ const FIRMWARE_PRODUCT_STRING_BTCONLY: &str = "BitBox02BTC";
 
 #[async_trait(?Send)]
 impl ReadWrite for hidapi::HidDevice {
-    fn write(&self, msg: &[u8]) -> Result<usize, CommuincationError> {
+    fn write(&self, msg: &[u8]) -> Result<usize, CommunicationError> {
         let mut v = vec![0x00];
         v.extend_from_slice(msg);
-        hidapi::HidDevice::write(self, &v).or(Err(CommuincationError::Write))
+        hidapi::HidDevice::write(self, &v).or(Err(CommunicationError::Write))
     }
 
-    async fn read(&self) -> Result<Vec<u8>, CommuincationError> {
+    async fn read(&self) -> Result<Vec<u8>, CommunicationError> {
         let mut buf = [0u8; 64];
-        let res = hidapi::HidDevice::read(self, &mut buf).or(Err(CommuincationError::Read))?;
+        let res = hidapi::HidDevice::read(self, &mut buf).or(Err(CommunicationError::Read))?;
         Ok(buf[..res].to_vec())
     }
 }

--- a/src/wasm/connect.rs
+++ b/src/wasm/connect.rs
@@ -62,7 +62,7 @@ pub async fn bitbox02_connect_webhid() -> Result<BitBox, JavascriptError> {
         write_function,
         read_function,
     });
-    let communication = Box::new(communication::U2fCommunication::from(
+    let communication = Box::new(communication::U2fHidCommunication::from(
         read_write,
         communication::FIRMWARE_CMD,
     ));

--- a/src/wasm/connect.rs
+++ b/src/wasm/connect.rs
@@ -58,15 +58,16 @@ pub async fn bitbox02_connect_webhid() -> Result<BitBox, JavascriptError> {
             "`read` object is not a function",
         )))?;
 
-    let read_write = JsReadWrite {
+    let read_write = Box::new(JsReadWrite {
         write_function,
         read_function,
-    };
+    });
+    let communication = Box::new(communication::U2fCommunication::from(
+        read_write,
+        communication::FIRMWARE_CMD,
+    ));
+
     Ok(BitBox(
-        crate::BitBox::from(
-            Box::new(read_write),
-            Box::new(noise::LocalStorageNoiseConfig {}),
-        )
-        .await?,
+        crate::BitBox::from(communication, Box::new(noise::LocalStorageNoiseConfig {})).await?,
     ))
 }

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -25,10 +25,13 @@ pub enum JavascriptError {
     #[assoc(js_code = "unknown-js".into())]
     Unknown,
     #[error(
-        "Could not open device. It might already have an open connection to this or another app."
+        "Could not open device. It might already have an open connection to another app. If so, please close the other app first."
     )]
     #[assoc(js_code = "could-not-open".into())]
-    CouldNotOpen,
+    CouldNotOpenWebHID,
+    #[error("Could not open device. {0}")]
+    #[assoc(js_code = "could-not-open".into())]
+    CouldNotOpenBridge(String),
     #[error("connection aborted by user")]
     #[assoc(js_code="user-abort".into())]
     UserAbort,

--- a/webhid.js
+++ b/webhid.js
@@ -1,5 +1,9 @@
 export async function jsSleep(ms) {
-    await new Promise(resolve => setTimeout(resolve, ms));
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function hasWebHID() {
+  return !!navigator.hid;
 }
 
 class MessageQueue {
@@ -52,11 +56,11 @@ export async function getWebHIDDevice(vendorId, productId) {
   const onInputReport = event => {
     msgQueue.addMessage(new Uint8Array(event.data.buffer));
   };
-  device.addEventListener("inputreport", onInputReport);
+  device.addEventListener('inputreport', onInputReport);
   return {
     write: bytes => {
       if (!device.opened) {
-        console.error("attempted write to a closed HID connection");
+        console.error('attempted write to a closed HID connection');
         return;
       }
       device.sendReport(0, bytes);
@@ -66,9 +70,73 @@ export async function getWebHIDDevice(vendorId, productId) {
     },
     close: () => {
       device.close().then(() => {
-        device.removeEventListener("inputreport", onInputReport);
+        device.removeEventListener('inputreport', onInputReport);
       });
     },
     valid: () => device.opened,
   };
+}
+
+
+async function getDevicePath() {
+  const attempts = 10;
+  for (let i = 0; i < attempts; i++){
+    let response;
+    let errorMessage;
+    try {
+      response = await fetch('http://localhost:8178/api/v1/devices', {
+        method: 'GET',
+        headers: {},
+      })
+      if (!response.ok && response.status === 403) {
+        errorMessage = 'Origin not whitelisted.';
+        throw new Error();
+      } else if (!response.ok) {
+        errorMessage = 'Unexpected bridge connection error.';
+        throw new Error();
+      }
+    } catch(err) {
+      throw new Error(errorMessage ? errorMessage : 'BitBoxBridge not found.');
+    }
+    const devices = (await response.json()).devices;
+    if (devices.length !== 1) {
+      await jsSleep(100);
+      continue;
+    }
+    const devicePath = devices[0].path;
+    return devicePath;
+  }
+  throw new Error('Expected exactly one BitBox02. If one is connected, it might already have an open connection another app. If so, please close the other app first.');
+}
+
+export async function getBridgeDevice() {
+  let devicePath = await getDevicePath();
+  const socket = new WebSocket('ws://127.0.0.1:8178/api/v1/socket/' + devicePath);
+  const msgQueue = new MessageQueue();
+
+  return new Promise((resolve, reject) => {
+    socket.binaryType = 'arraybuffer';
+    socket.onmessage = event => { msgQueue.addMessage(new Uint8Array(event.data)); };
+    socket.onopen = function (event) {
+      resolve({
+        write: bytes => {
+          if (socket.readyState != WebSocket.OPEN) {
+            console.error('attempted write to a closed socket');
+            return;
+          }
+          socket.send(bytes);
+        },
+        read: async () => {
+          return await msgQueue.getNextMessage();
+        },
+        close: () => socket.close(),
+        valid: () => {
+          return socket.readyState == WebSocket.OPEN;
+        },
+      });
+    };
+    socket.onerror = function(event) {
+      reject(new Error('Your BitBox02 is busy.'));
+    };
+  });
 }


### PR DESCRIPTION
Before, `BitBox::from()` internally created a U2fCommunication framing layer. We remove this and fold it into the ReadWrite trait that `BitBox::from` already takes. This way, the connection code can choose the framing. This will allow making a BitBoxBridge communication layer, which uses a modified u2f framing protocol.