### PR TITLE
eth: remove leading zeroes in eth tx fields

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -421,11 +421,11 @@ impl<R: Runtime> PairedBitBox<R> {
         let request = pb::eth_request::Request::Sign(pb::EthSignRequest {
             coin: 0,
             keypath: keypath.to_vec(),
-            nonce: tx.nonce.clone(),
-            gas_price: tx.gas_price.clone(),
-            gas_limit: tx.gas_limit.clone(),
+            nonce: crate::util::remove_leading_zeroes(&tx.nonce),
+            gas_price: crate::util::remove_leading_zeroes(&tx.gas_price),
+            gas_limit: crate::util::remove_leading_zeroes(&tx.gas_limit),
             recipient: tx.recipient.to_vec(),
-            value: tx.value.clone(),
+            value: crate::util::remove_leading_zeroes(&tx.value),
             data: tx.data.clone(),
             host_nonce_commitment: Some(pb::AntiKleptoHostNonceCommitment {
                 commitment: crate::antiklepto::host_commit(&host_nonce).to_vec(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod communication;
 mod constants;
 mod keypath;
 mod u2fframing;
+mod util;
 
 /// BitBox protobuf messages.
 pub mod pb {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,34 @@
+pub fn remove_leading_zeroes(list: &[u8]) -> Vec<u8> {
+    if let Some(first_non_zero) = list.iter().position(|&x| x != 0) {
+        list[first_non_zero..].to_vec()
+    } else {
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_remove_leading_zeroes() {
+        // Test with leading zeroes
+        let data = &[0, 0, 0, 1, 2, 3, 0, 4];
+        let result = remove_leading_zeroes(data);
+        assert_eq!(result, vec![1, 2, 3, 0, 4]);
+
+        // Test with no leading zeroes
+        let data = &[1, 0, 0, 1, 2, 3, 0, 4];
+        let result = remove_leading_zeroes(data);
+        assert_eq!(result, vec![1, 0, 0, 1, 2, 3, 0, 4]);
+
+        // Test with all zeroes
+        let data = &[0, 0, 0, 0, 0];
+        let result = remove_leading_zeroes(data);
+        assert_eq!(result, Vec::<u8>::new());
+
+        // Test with an empty list
+        let data = &[];
+        let result = remove_leading_zeroes(data);
+        assert_eq!(result, Vec::<u8>::new());
+    }
+}

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -129,14 +129,6 @@ impl PairingBitBox {
     }
 }
 
-fn remove_leading_zeroes(list: &[u8]) -> Vec<u8> {
-    if let Some(first_non_zero) = list.iter().position(|&x| x != 0) {
-        list[first_non_zero..].to_vec()
-    } else {
-        Vec::new()
-    }
-}
-
 fn compute_v(chain_id: u64, rec_id: u8) -> Option<u64> {
     let v_offset: u64 = chain_id.checked_mul(2)?.checked_add(8)?;
     (rec_id as u64 + 27).checked_add(v_offset)
@@ -300,7 +292,7 @@ impl PairedBitBox {
         Ok(serde_wasm_bindgen::to_value(&types::EthSignature {
             r: signature[..32].to_vec(),
             s: signature[32..64].to_vec(),
-            v: remove_leading_zeroes(&v.to_be_bytes()),
+            v: crate::util::remove_leading_zeroes(&v.to_be_bytes()),
         })
         .unwrap()
         .into())


### PR DESCRIPTION
BitBox02 enforces no leading zeroes in these fields. Better UX for library users if they don't have to strip it manually.