### PR TITLE
BitBox: feature multithreaded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ codegen-units = 1
 lto = true
 
 [features]
+multithreaded = []
 usb = ["dep:hidapi"]
 wasm = [
   "dep:enum-assoc",

--- a/src/btc.rs
+++ b/src/btc.rs
@@ -533,6 +533,7 @@ pub fn make_script_config_simple(
     derive(serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
+#[derive(PartialEq)]
 pub struct KeyOriginInfo {
     pub root_fingerprint: Option<bitcoin::bip32::Fingerprint>,
     pub keypath: Option<Keypath>,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,6 +1,13 @@
 use async_trait::async_trait;
 
+#[cfg(feature = "wasm")]
 #[async_trait(?Send)]
+pub trait Runtime {
+    async fn sleep(dur: std::time::Duration);
+}
+
+#[cfg(not(feature = "wasm"))]
+#[async_trait]
 pub trait Runtime {
     async fn sleep(dur: std::time::Duration);
 }
@@ -9,7 +16,8 @@ pub trait Runtime {
 /// Useful if using futures::executor::block_on() to run synchronously.
 pub struct DefaultRuntime;
 
-#[async_trait(?Send)]
+#[cfg(not(feature = "wasm"))]
+#[async_trait]
 impl Runtime for DefaultRuntime {
     async fn sleep(dur: std::time::Duration) {
         std::thread::sleep(dur);
@@ -20,7 +28,7 @@ impl Runtime for DefaultRuntime {
 pub struct TokioRuntime;
 
 #[cfg(feature = "tokio")]
-#[async_trait(?Send)]
+#[async_trait]
 impl Runtime for TokioRuntime {
     async fn sleep(dur: std::time::Duration) {
         tokio::time::sleep(dur).await

--- a/src/wasm/connect.rs
+++ b/src/wasm/connect.rs
@@ -43,7 +43,7 @@ impl communication::ReadWrite for JsReadWrite {
     }
 }
 
-fn get_read_writer(result: &JsValue) -> Result<Box<JsReadWrite>, JavascriptError> {
+fn get_read_writer(result: &JsValue) -> Result<JsReadWrite, JavascriptError> {
     let write_function: js_sys::Function = js_sys::Reflect::get(result, &"write".into())
         .or(Err(JavascriptError::InvalidType("`write` key missing")))?
         .dyn_into()
@@ -57,10 +57,10 @@ fn get_read_writer(result: &JsValue) -> Result<Box<JsReadWrite>, JavascriptError
             "`read` object is not a function",
         )))?;
 
-    Ok(Box::new(JsReadWrite {
+    Ok(JsReadWrite {
         write_function,
         read_function,
-    }))
+    })
 }
 
 /// Connect to a BitBox02 using WebHID. WebHID is mainly supported by Chrome.
@@ -104,7 +104,7 @@ pub async fn bitbox02_connect_bridge(on_close_cb: TsOnCloseCb) -> Result<BitBox,
     }
     let read_write = get_read_writer(&result)?;
     let communication = Box::new(communication::U2fWsCommunication::from(
-        read_write,
+        Box::new(read_write),
         communication::FIRMWARE_CMD,
     ));
 


### PR DESCRIPTION
This new feature does not modify the current API of the BitBox, but enables the use of the library in the async-hwi crate which has some requirements in terms of synchronicity with threads.