### PR TITLE
allow for multithreaded use of PairingBitBox and PairedBitBox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,12 @@ futures = { version = "0.3.28", default-features = false, features = ["executor"
 prost-build = { version = "0.11" }
 
 [[example]]
-name = "connect"
+name = "singlethreaded"
 required-features = ["usb", "tokio/rt", "tokio/macros"]
+
+[[example]]
+name = "multithreaded"
+required-features = ["usb", "tokio/rt", "tokio/macros", "tokio/rt-multi-thread", "multithreaded"]
 
 [[example]]
 name = "btc_signtx"
@@ -74,6 +78,9 @@ codegen-units = 1
 lto = true
 
 [features]
+# Implement Sync+Send for PairedBitBox and PairingBitBox.
+# This may or may not cause trouble on macOS, see: https://github.com/libusb/hidapi/issues/503
+multithreaded = []
 usb = ["dep:hidapi"]
 wasm = [
   "dep:enum-assoc",

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-example:
-	cargo run --example connect --features=usb,tokio/rt,tokio/macros
+example-singlethreaded:
+	cargo run --example singlethreaded --features=usb,tokio/rt,tokio/macros
+example-multithreaded:
+	cargo run --example multithreaded --features=usb,tokio/rt,tokio/macros,tokio/rt-multi-thread,multithreaded
 example-btc-signtx:
 	cargo run --example btc_signtx --features=usb,tokio/rt,tokio/macros
 example-btc-psbt:

--- a/ci.sh
+++ b/ci.sh
@@ -6,10 +6,12 @@ features=(
   "usb"
   "usb,serde"
   "wasm"
+  "multithreaded,usb,serde"
 )
 
 examples=(
-  "--example connect --features=usb,tokio/rt,tokio/macros"
+  "--example singlethreaded --features=usb,tokio/rt,tokio/macros"
+  "--example multithreaded --features=usb,tokio/rt,tokio/macros,tokio/rt-multi-thread,multithreaded"
   " --example btc_signtx --features=usb,tokio/rt,tokio/macros"
   "--example btc_sign_psbt --features=usb,tokio/rt,tokio/macros"
   "--example btc_miniscript --features=usb,tokio/rt,tokio/macros"

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -1,0 +1,25 @@
+fn multithreading_type_check<T: Sync + Send>(_t: &T) {}
+
+async fn demo<R: bitbox_api::runtime::Runtime + Sync + Send>() {
+    let noise_config = Box::new(bitbox_api::NoiseConfigNoCache {});
+    let bitbox =
+        bitbox_api::BitBox::<R>::from(bitbox_api::usb::get_any_bitbox02().unwrap(), noise_config)
+            .await
+            .unwrap();
+    let pairing_bitbox = bitbox.unlock_and_pair().await.unwrap();
+    if let Some(pairing_code) = pairing_bitbox.get_pairing_code().as_ref() {
+        println!("Pairing code\n{}", pairing_code);
+    }
+    multithreading_type_check(&pairing_bitbox);
+    let paired_bitbox = pairing_bitbox.wait_confirm().await.unwrap();
+    println!(
+        "root fingerprint: {}",
+        paired_bitbox.root_fingerprint().await.unwrap()
+    );
+    multithreading_type_check(&paired_bitbox);
+}
+
+#[tokio::main]
+async fn main() {
+    demo::<bitbox_api::runtime::TokioRuntime>().await
+}

--- a/examples/singlethreaded.rs
+++ b/examples/singlethreaded.rs
@@ -1,4 +1,4 @@
-async fn demo<R: bitbox_api::runtime::Runtime>() {
+async fn demo<R: bitbox_api::runtime::Runtime + Sync + Send>() {
     let noise_config = Box::new(bitbox_api::NoiseConfigNoCache {});
     let bitbox =
         bitbox_api::BitBox::<R>::from(bitbox_api::usb::get_any_bitbox02().unwrap(), noise_config)
@@ -13,27 +13,6 @@ async fn demo<R: bitbox_api::runtime::Runtime>() {
         "root fingerprint: {}",
         paired_bitbox.root_fingerprint().await.unwrap()
     );
-
-    paired_bitbox
-        .btc_xpub(
-            bitbox_api::pb::BtcCoin::Btc,
-            &"m/84'/0'/0'".try_into().unwrap(),
-            bitbox_api::pb::btc_pub_request::XPubType::Xpub,
-            true,
-        )
-        .await
-        .unwrap();
-    paired_bitbox
-        .btc_address(
-            bitbox_api::pb::BtcCoin::Btc,
-            &"m/84'/0'/0'/0/0".try_into().unwrap(),
-            &bitbox_api::btc::make_script_config_simple(
-                bitbox_api::pb::btc_script_config::SimpleType::P2wpkh,
-            ),
-            true,
-        )
-        .await
-        .unwrap();
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -1,3 +1,4 @@
+use crate::util::Threading;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -39,7 +40,7 @@ impl NoiseConfigData {
     }
 }
 
-pub trait NoiseConfig {
+pub trait NoiseConfig: Threading {
     fn read_config(&self) -> Result<NoiseConfigData, ConfigError> {
         Ok(NoiseConfigData::default())
     }
@@ -50,10 +51,13 @@ pub trait NoiseConfig {
 
 pub struct NoiseConfigNoCache;
 impl NoiseConfig for NoiseConfigNoCache {}
+impl Threading for NoiseConfigNoCache {}
 
 pub struct PersistedNoiseConfig {
     config_dir: String,
 }
+
+impl Threading for PersistedNoiseConfig {}
 
 impl PersistedNoiseConfig {
     /// Creates a new persisting noise config, which stores the pairing information in "bitbox.json"

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "multithreaded", async_trait)]
+#[cfg_attr(not(feature="multithreaded"), async_trait(?Send))]
 pub trait Runtime {
     async fn sleep(dur: std::time::Duration);
 }
@@ -9,7 +10,8 @@ pub trait Runtime {
 /// Useful if using futures::executor::block_on() to run synchronously.
 pub struct DefaultRuntime;
 
-#[async_trait(?Send)]
+#[cfg_attr(feature = "multithreaded", async_trait)]
+#[cfg_attr(not(feature="multithreaded"), async_trait(?Send))]
 impl Runtime for DefaultRuntime {
     async fn sleep(dur: std::time::Duration) {
         std::thread::sleep(dur);
@@ -20,7 +22,8 @@ impl Runtime for DefaultRuntime {
 pub struct TokioRuntime;
 
 #[cfg(feature = "tokio")]
-#[async_trait(?Send)]
+#[cfg_attr(feature = "multithreaded", async_trait)]
+#[cfg_attr(not(feature="multithreaded"), async_trait(?Send))]
 impl Runtime for TokioRuntime {
     async fn sleep(dur: std::time::Duration) {
         tokio::time::sleep(dur).await

--- a/src/util.rs
+++ b/src/util.rs
@@ -32,3 +32,9 @@ mod tests {
         assert_eq!(result, Vec::<u8>::new());
     }
 }
+
+#[cfg(feature = "multithreaded")]
+pub trait Threading: Sync + Send {}
+
+#[cfg(not(feature = "multithreaded"))]
+pub trait Threading {}

--- a/src/wasm/connect.rs
+++ b/src/wasm/connect.rs
@@ -1,11 +1,13 @@
 use super::{noise, types::TsOnCloseCb, BitBox, JavascriptError};
+use crate::communication;
 use wasm_bindgen::prelude::*;
 
 struct JsReadWrite {
     write_function: js_sys::Function,
     read_function: js_sys::Function,
 }
-use crate::communication;
+
+impl crate::util::Threading for JsReadWrite {}
 
 #[wasm_bindgen(raw_module = "./webhid")]
 extern "C" {

--- a/src/wasm/noise.rs
+++ b/src/wasm/noise.rs
@@ -7,6 +7,8 @@ pub static LOCAL_STORAGE_CONFIG_KEY: &str = "bitbox02Config";
 /// Store the noise keys in the browser localstorage if possible.
 pub(crate) struct LocalStorageNoiseConfig {}
 
+impl crate::util::Threading for LocalStorageNoiseConfig {}
+
 impl crate::NoiseConfig for LocalStorageNoiseConfig {
     fn read_config(&self) -> Result<NoiseConfigData, ConfigError> {
         localstorage::get(LOCAL_STORAGE_CONFIG_KEY).or(Ok(NoiseConfigData::default()))


### PR DESCRIPTION
Generally, the hidapi based communication should be single-threaded, as on macOS, we have seen communication issues when the hidapi calls move between threads. See https://github.com/libusb/hidapi/issues/503.

The above issue is unresolved and unexplained, and might only happen in combination with the Go runtime, Nevertheless, it is safer to use it only single-threaded, to avoid potential issues.

This commit enables Sync+Send (multithreading) by activating the "multithreaded" feature for when multithreading is required. Sync/Send cannot be activated in WASM as the function pointers in JsReadWrite do not implement Sync/Send.