### PR TITLE
make NoiseConfigData public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bitbox-api"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitbox-api"
 authors = ["Marko Bencun <benma@bitbox.swiss>"]
-version = "0.1.5"
+version = "0.1.6"
 homepage = "https://bitbox.swiss/"
 repository = "https://github.com/digitalbitbox/bitbox-api-rs/"
 readme = "README-rust.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ use std::sync::Mutex;
 
 pub use keypath::Keypath;
 pub use noise::PersistedNoiseConfig;
-pub use noise::{NoiseConfig, NoiseConfigNoCache};
+pub use noise::{NoiseConfig, NoiseConfigData, NoiseConfigNoCache};
 
 use communication::HwwCommunication;
 


### PR DESCRIPTION
Difficult otherwise to make external implementation of NoiseConfig trait.

Fixes #39