### PR TITLE
make util::Threading public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bitbox-api"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitbox-api"
 authors = ["Marko Bencun <benma@bitbox.swiss>"]
-version = "0.1.6"
+version = "0.1.7"
 homepage = "https://bitbox.swiss/"
 repository = "https://github.com/digitalbitbox/bitbox-api-rs/"
 readme = "README-rust.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ use std::sync::Mutex;
 pub use keypath::Keypath;
 pub use noise::PersistedNoiseConfig;
 pub use noise::{NoiseConfig, NoiseConfigData, NoiseConfigNoCache};
+pub use util::Threading;
 
 use communication::HwwCommunication;
 


### PR DESCRIPTION
So that the NoiseConfig trait (which relies on `Threading`) can be implemented by clients.

Fixes #42