### PR TITLE
Make noise ConfigError public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ use std::sync::Mutex;
 
 pub use keypath::Keypath;
 pub use noise::PersistedNoiseConfig;
-pub use noise::{NoiseConfig, NoiseConfigData, NoiseConfigNoCache};
+pub use noise::{ConfigError, NoiseConfig, NoiseConfigData, NoiseConfigNoCache};
 pub use util::Threading;
 
 use communication::HwwCommunication;

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 #[error("{0}")]
 pub struct ConfigError(pub String);
 
-#[derive(Default, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct NoiseConfigData {
     pub app_static_privkey: Option<[u8; 32]>,
     pub device_static_pubkeys: Vec<Vec<u8>>,


### PR DESCRIPTION
I successfully have an external implementation of NoiseConfig.
I think no error was returned by the compiler for the trait, because the ConfigError is indeed public in the module, but the module is private in lib.rs
close #44 