### PR TITLE
frontend/sandbox: fixed and restyled error alert component

### DIFF
--- a/sandbox/src/App.tsx
+++ b/sandbox/src/App.tsx
@@ -83,7 +83,7 @@ function App() {
       <button className="menuButton" onClick={() => connect('webHID')}>Connect using WebHID</button><br />
       <button className="menuButton" onClick={() => connect('bridge')}>Connect using BitBoxBridge</button><br />
       <button className="menuButton" onClick={() => connect('auto')}>Choose automatically</button>
-      {err !== undefined && <ErrorNotification err={JSON.stringify(err)} onClose={() => setErr(undefined)} /> }
+      {err !== undefined && <ErrorNotification message={err.message} code={err.code} onClose={() => setErr(undefined)} /> }
     </div>
   );
 }

--- a/sandbox/src/Error.tsx
+++ b/sandbox/src/Error.tsx
@@ -14,6 +14,10 @@ export function ShowError({ err }: { err?: bitbox.Error }) {
   }
 
   return (
-    <ErrorNotification err={JSON.stringify(err)} onClose={() => setError(undefined)} />
+    <ErrorNotification
+      message={error.message}
+      code={error.code}
+      onClose={() => setError(undefined)}
+    />
   );
 }

--- a/sandbox/src/ErrorNotification.css
+++ b/sandbox/src/ErrorNotification.css
@@ -7,19 +7,27 @@
 	border: 4px solid #dd757b;
 	top: 32px;
 	right: 32px;
+	width: 100%;
+	max-width: 400px;
+	text-align: left;
 }
 
-.alert pre {
-	font-size: 16px;
-	width: 400px;
-	text-wrap: wrap;
+.alert p {
+	margin: 16px 0;
+}
+
+.alert kbd {
+	background-color: #dd757b;
+	padding: 4px 8px;
+	border-radius: 4px;
+	color: #fbeaea;
+	display: inline-block;
 }
 
 .headerContainer {
 	display: flex;
 	align-items: center;
 	width: 100%;
-	margin-bottom: 8px;
 }
 
 .alert h2 {
@@ -44,7 +52,8 @@
 
 @media (max-width: 768px) {
 	.alert {
-		left: 32px;
+		right: 32px;
+		max-width: 280px;
 	}
 
 	.alert pre {

--- a/sandbox/src/ErrorNotification.tsx
+++ b/sandbox/src/ErrorNotification.tsx
@@ -2,17 +2,20 @@ import { useEffect } from "react";
 import "./ErrorNotification.css";
 
 type TProps = {
-    err: string;
+    message: string;
+    code: string;
     onClose: () => void;
 }
 
-export const ErrorNotification = ({ err, onClose }: TProps) => {
+export const ErrorNotification = ({ message, code, onClose }: TProps) => {
   
   useEffect(() => {
-    setTimeout(() => {
+    const timerId = setTimeout(() => {
       onClose();
-    }, 3500)
-  }, [err, onClose]);
+    }, 3500);
+
+    return () => clearTimeout(timerId);
+  }, [message, onClose]);
 
   return (
       <div className="alert">
@@ -20,7 +23,8 @@ export const ErrorNotification = ({ err, onClose }: TProps) => {
             <h2>Error</h2>
             <button onClick={onClose}>X</button>
           </div>
-          <pre>{err}</pre>
+      <p>{message}</p>
+      <kbd>code: {code}</kbd>
       </div>
   )
 }


### PR DESCRIPTION
Addresses issue: #51

Fixing inconsistent removal of alert due to not clearing timerId on component unmounts, as well as restyling the alert so error can be read easier:

[Preview]:

<img width="1485" alt="xasko" src="https://github.com/digitalbitbox/bitbox-api-rs/assets/28676406/7ec2cc43-47e6-4440-bd5b-24549cac3536">
