### PR TITLE
src: BTC sign message implemented and tested

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,10 @@ name = "btc_sign_psbt"
 required-features = ["usb", "tokio/rt", "tokio/macros"]
 
 [[example]]
+name = "btc_sign_msg"
+required-features = ["usb", "tokio/rt", "tokio/macros"]
+
+[[example]]
 name = "btc_miniscript"
 required-features = ["usb", "tokio/rt", "tokio/macros"]
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ example-btc-signtx:
 	cargo run --example btc_signtx --features=usb,tokio/rt,tokio/macros
 example-btc-psbt:
 	cargo run --example btc_sign_psbt --features=usb,tokio/rt,tokio/macros
+example-btc-sign-msg:
+	cargo run --example btc_sign_msg --features=usb,tokio/rt,tokio/macros
 example-btc-miniscript:
 	cargo run --example btc_miniscript --features=usb,tokio/rt,tokio/macros
 example-eth:

--- a/ci.sh
+++ b/ci.sh
@@ -13,6 +13,7 @@ examples=(
   "--example multithreaded --features=usb,tokio/rt,tokio/macros,tokio/rt-multi-thread,multithreaded"
   " --example btc_signtx --features=usb,tokio/rt,tokio/macros"
   "--example btc_sign_psbt --features=usb,tokio/rt,tokio/macros"
+  "--example btc_sign_msg --features=usb,tokio/rt,tokio/macros"
   "--example btc_miniscript --features=usb,tokio/rt,tokio/macros"
   "--example eth --features=usb,tokio/rt,tokio/macros,rlp"
   "--example cardano --features=usb,tokio/rt,tokio/macros"

--- a/examples/btc_sign_msg.rs
+++ b/examples/btc_sign_msg.rs
@@ -1,0 +1,37 @@
+use bitbox_api::pb;
+
+async fn signmsg<R: bitbox_api::runtime::Runtime>() {
+    let noise_config = Box::new(bitbox_api::NoiseConfigNoCache {});
+    let bitbox = bitbox_api::BitBox::<R>::from_hid_device(
+        bitbox_api::usb::get_any_bitbox02().unwrap(),
+        noise_config,
+    )
+    .await
+    .unwrap();
+    let pairing_bitbox = bitbox.unlock_and_pair().await.unwrap();
+    if let Some(pairing_code) = pairing_bitbox.get_pairing_code().as_ref() {
+        println!("Pairing code\n{}", pairing_code);
+    }
+    let paired_bitbox = pairing_bitbox.wait_confirm().await.unwrap();
+
+    let keypath = bitbox_api::Keypath::try_from("m/49'/0'/0'/0/0").unwrap();
+
+    let script_config_sign_msg: Option<pb::BtcScriptConfigWithKeypath> =
+        Some(pb::BtcScriptConfigWithKeypath {
+            script_config: Some(bitbox_api::btc::make_script_config_simple(
+                pb::btc_script_config::SimpleType::P2wpkhP2sh,
+            )),
+            keypath: keypath.to_vec(),
+        });
+
+    let signature = paired_bitbox
+        .btc_sign_message(pb::BtcCoin::Btc, script_config_sign_msg, b"message")
+        .await
+        .unwrap();
+    println!("Signature: {:?}", signature);
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    signmsg::<bitbox_api::runtime::TokioRuntime>().await
+}


### PR DESCRIPTION
Addresses the request in the issue : #49 

The implementation of BTC message signing has been completed and it also supports antiklepto verification. Furthermore, a test is added as an example in 'examples' folder.