### PR TITLE
btc: Expose sign_message() to TS API and create UI

### DIFF
--- a/examples/btc_sign_msg.rs
+++ b/examples/btc_sign_msg.rs
@@ -16,13 +16,12 @@ async fn signmsg<R: bitbox_api::runtime::Runtime>() {
 
     let keypath = bitbox_api::Keypath::try_from("m/49'/0'/0'/0/0").unwrap();
 
-    let script_config_sign_msg: Option<pb::BtcScriptConfigWithKeypath> =
-        Some(pb::BtcScriptConfigWithKeypath {
-            script_config: Some(bitbox_api::btc::make_script_config_simple(
-                pb::btc_script_config::SimpleType::P2wpkhP2sh,
-            )),
-            keypath: keypath.to_vec(),
-        });
+    let script_config_sign_msg: pb::BtcScriptConfigWithKeypath = pb::BtcScriptConfigWithKeypath {
+        script_config: Some(bitbox_api::btc::make_script_config_simple(
+            pb::btc_script_config::SimpleType::P2wpkhP2sh,
+        )),
+        keypath: keypath.to_vec(),
+    };
 
     let signature = paired_bitbox
         .btc_sign_message(pb::BtcCoin::Btc, script_config_sign_msg, b"message")

--- a/src/btc.rs
+++ b/src/btc.rs
@@ -198,7 +198,7 @@ pub struct Transaction {
     pub locktime: u32,
 }
 // See https://github.com/spesmilo/electrum/blob/84dc181b6e7bb20e88ef6b98fb8925c5f645a765/electrum/ecc.py#L521-L523
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, serde::Serialize)]
 pub struct SignMessageSignature {
     pub sig: Vec<u8>,
     pub recid: u8,
@@ -863,7 +863,7 @@ impl<R: Runtime> PairedBitBox<R> {
     pub async fn btc_sign_message(
         &self,
         coin: pb::BtcCoin,
-        script_config: Option<pb::BtcScriptConfigWithKeypath>,
+        script_config: pb::BtcScriptConfigWithKeypath,
         msg: &[u8],
     ) -> Result<SignMessageSignature, Error> {
         self.validate_version(">=9.5.0")?;
@@ -871,7 +871,7 @@ impl<R: Runtime> PairedBitBox<R> {
         let host_nonce = crate::antiklepto::gen_host_nonce()?;
         let request = pb::BtcSignMessageRequest {
             coin: coin as _,
-            script_config,
+            script_config: Some(script_config),
             msg: msg.to_vec(),
             host_nonce_commitment: Some(pb::AntiKleptoHostNonceCommitment {
                 commitment: crate::antiklepto::host_commit(&host_nonce).to_vec(),

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -334,6 +334,21 @@ impl PairedBitBox {
         Ok(psbt.to_string())
     }
 
+    #[wasm_bindgen(js_name = btcSignMessage)]
+    pub async fn btc_sign_message(
+        &self,
+        coin: types::TsBtcCoin,
+        script_config: types::TsBtcScriptConfigWithKeypath,
+        msg: &[u8],
+    ) -> Result<types::TsBtcSignMessageSignature, JavascriptError> {
+        let signature = self
+            .0
+            .btc_sign_message(coin.try_into()?, script_config.try_into()?, msg)
+            .await?;
+
+        Ok(serde_wasm_bindgen::to_value(&signature).unwrap().into())
+    }
+
     /// Does this device support ETH functionality? Currently this means BitBox02 Multi.
     #[wasm_bindgen(js_name = ethSupported)]
     pub fn eth_supported(&self) -> bool {

--- a/src/wasm/types.rs
+++ b/src/wasm/types.rs
@@ -38,6 +38,11 @@ type BtcScriptConfigWithKeypath = {
   scriptConfig: BtcScriptConfig;
   keypath: Keypath;
 };
+type BtcSignMessageSignature = {
+  sig: Uint8Array,
+  recid: bigint,
+  electrumSig65: Uint8Array,
+}
 // nonce, gasPrice, gasLimit and value must be big-endian encoded, no trailing zeroes.
 type EthTransaction = {
   nonce: Uint8Array;
@@ -155,6 +160,8 @@ extern "C" {
     pub type TsBtcScriptConfig;
     #[wasm_bindgen(typescript_type = "BtcScriptConfigWithKeypath")]
     pub type TsBtcScriptConfigWithKeypath;
+    #[wasm_bindgen(typescript_type = "BtcSignMessageSignature")]
+    pub type TsBtcSignMessageSignature;
     #[wasm_bindgen(typescript_type = "EthTransaction")]
     pub type TsEthTransaction;
     #[wasm_bindgen(typescript_type = "EthSignature")]


### PR DESCRIPTION
After implementing BTC message signing for Rust API, further extensions are added to make wasm expose this functionality to TypeScript API. Finally, an extra field added under the Bitcoin section of sandbox UI app for BTC message signing.