### PR TITLE
Cargo.toml: bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bitbox-api"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitbox-api"
 authors = ["Marko Bencun <benma@bitbox.swiss>"]
-version = "0.1.8"
+version = "0.2.0"
 homepage = "https://bitbox.swiss/"
 repository = "https://github.com/digitalbitbox/bitbox-api-rs/"
 readme = "README-rust.md"

--- a/sandbox/package-lock.json
+++ b/sandbox/package-lock.json
@@ -30,7 +30,7 @@
     },
     "../pkg": {
       "name": "bitbox-api",
-      "version": "0.1.7",
+      "version": "0.2.0",
       "license": "Apache-2.0"
     },
     "node_modules/@aashutoshrathi/word-wrap": {


### PR DESCRIPTION
btc_sign_msg() added to Rust and WASM.