### PR TITLE
sandbox: create workflow to deploy sandbox on github pages

### DIFF
--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -1,0 +1,43 @@
+name: Build and Deploy Sandbox to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 
+
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+  
+    - name: Install wasm-pack, clang, and jq
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang jq
+        cargo install --force wasm-pack
+
+    - name: Build WASM
+      run: |
+        make wasm
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18' 
+    
+    - name: Install Sandbox Dependencies and Build Sandbox
+      run: |
+        make build-sandbox
+
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: gh-pages  
+        folder: sandbox/dist     
+        token: ${{ secrets.GITHUB_TOKEN }} 

--- a/sandbox/vite.config.ts
+++ b/sandbox/vite.config.ts
@@ -6,4 +6,5 @@ import topLevelAwait from "vite-plugin-top-level-await";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), wasm(), topLevelAwait()],
+  base: '/bitbox-api-rs/'
 })


### PR DESCRIPTION
Addresses: #63 

1. Created a new workflow `deploy-sandbox.yml`.
2. Changed `vite.config.js` `base` according to the [docs on deploying on GitHub Pages.](https://vitejs.dev/guide/static-deploy)

The workflow will build the sandbox on every push to `master` branch. The build files will then be automatically pushed to a branch called `gh-pages`. This `gh-pages` branch is where GitHub Pages will deploy the sandbox (static site) from.