### PR TITLE
Add firmware simulator v9.26.3

### DIFF
--- a/src/eth.rs
+++ b/src/eth.rs
@@ -418,12 +418,12 @@ fn get_value(
                     .get(&typ.struct_name)
                     .ok_or(format!(
                         "could not lookup type of name: {}",
-                        &typ.struct_name
+                        typ.struct_name
                     ))?
                     .get(*element as usize)
                     .ok_or(format!(
                         "could not lookup member #{} of type: {}",
-                        *element, &typ.struct_name
+                        *element, typ.struct_name
                     ))?;
                 value = Either::JsonValue(
                     value

--- a/tests/simulators.json
+++ b/tests/simulators.json
@@ -30,5 +30,9 @@
     {
         "url": "https://github.com/BitBoxSwiss/bitbox02-firmware/releases/download/firmware%2Fv9.26.1/bitbox02-multi-v9.26.1-simulator1.0.0-linux-amd64",
         "sha256": "91ddf47eb0653ce8b3d3344a8e329fc7fef90adfa51e39c5214830cf6e21cccf"
+    },
+    {
+        "url": "https://github.com/BitBoxSwiss/bitbox02-firmware/releases/download/firmware%2Fv9.26.3/bitbox02-multi-v9.26.3-simulator1.0.0-linux-amd64",
+        "sha256": "606e1fe6845430a47d1ecbda1df77a3b5e43a5dd164d2568431bbfdc882004dc"
     }
 ]

--- a/tests/test_btc_psbt.rs
+++ b/tests/test_btc_psbt.rs
@@ -466,7 +466,7 @@ async fn test_btc_psbt_multisig_p2wsh() {
 
         let multi_descriptor: miniscript::Descriptor<miniscript::DescriptorPublicKey> = format!(
             "wsh(sortedmulti({},[{}/48'/1'/0'/2']{}/<0;1>/*,{}/<0;1>/*))",
-            threshold, our_root_fingerprint, &our_xpub, &some_xpub
+            threshold, our_root_fingerprint, our_xpub, some_xpub
         )
             .parse::<miniscript::Descriptor<miniscript::DescriptorPublicKey>>()
             .unwrap();
@@ -612,7 +612,7 @@ async fn test_btc_psbt_policy_wsh() {
         let multi_descriptor: miniscript::Descriptor<miniscript::DescriptorPublicKey> = policy
             .replace(
                 "@0",
-                &format!("[{}/48'/1'/0'/3']{}", &our_root_fingerprint, &our_xpub),
+                &format!("[{}/48'/1'/0'/3']{}", our_root_fingerprint, our_xpub),
             )
             .replace("@1", &some_xpub.to_string())
             .parse::<miniscript::Descriptor<miniscript::DescriptorPublicKey>>()
@@ -775,7 +775,7 @@ async fn test_btc_psbt_policy_tr_keyspend() {
         let multi_descriptor: miniscript::Descriptor<miniscript::DescriptorPublicKey> = policy
             .replace(
                 "@0",
-                &format!("[{}/48'/1'/0'/3']{}", &our_root_fingerprint, &our_xpub),
+                &format!("[{}/48'/1'/0'/3']{}", our_root_fingerprint, our_xpub),
             )
             .parse::<miniscript::Descriptor<miniscript::DescriptorPublicKey>>()
             .unwrap();
@@ -934,7 +934,7 @@ async fn test_btc_psbt_policy_tr_scriptspend() {
         let multi_descriptor: miniscript::Descriptor<miniscript::DescriptorPublicKey> = policy
             .replace(
                 "@1",
-                &format!("[{}/48'/1'/0'/3']{}", &our_root_fingerprint, &our_xpub),
+                &format!("[{}/48'/1'/0'/3']{}", our_root_fingerprint, our_xpub),
             )
             .replace("@0", &some_xpub.to_string())
             .parse::<miniscript::Descriptor<miniscript::DescriptorPublicKey>>()


### PR DESCRIPTION
Summary:
- Fix beta Clippy `useless_borrows_in_formatting` warnings in EIP-712 and PSBT formatting.
- Add the v9.26.3 BitBox02 simulator release to the simulator test data.

Tests:
- CI