### PR TITLE
feat: expose custom transport API via from_transport()

### DIFF
--- a/CHANGELOG-rust.md
+++ b/CHANGELOG-rust.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## 0.13.0
+- Add `BitBox::from_transport()`
+
 ## 0.12.1
 - Serialize public API calls that talk to the device to avoid interleaving request/response
   sequences and breaking the device communication state.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bitbox-api"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitbox-api"
 authors = ["Marko Bencun <benma@bitbox.swiss>"]
-version = "0.12.1"
+version = "0.13.0"
 homepage = "https://bitbox.swiss/"
 repository = "https://github.com/BitBoxSwiss/bitbox-api-rs/"
 readme = "README-rust.md"

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -6,7 +6,6 @@ use crate::util::Threading;
 use async_trait::async_trait;
 use thiserror::Error;
 
-#[cfg(any(feature = "wasm", feature = "usb", feature = "simulator"))]
 pub const FIRMWARE_CMD: u8 = 0x80 + 0x40 + 0x01;
 
 #[derive(Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub use util::Threading;
 use communication::HwwCommunication;
 
 pub use communication::Product;
+pub use communication::{Error as CommunicationError, ReadWrite};
 
 const OP_I_CAN_HAS_HANDSHAEK: u8 = b'h';
 const OP_HER_COMEZ_TEH_HANDSHAEK: u8 = b'H';
@@ -86,6 +87,25 @@ impl<R: Runtime> BitBox<R> {
         })
     }
 
+    /// Creates a new BitBox instance from a custom transport.
+    ///
+    /// The `transport` is a raw byte channel to the device (HID reports); this method wraps it
+    /// in the U2F-HID framing layer internally, so callers only need to implement
+    /// [`ReadWrite`] over their platform-specific transport.
+    ///
+    /// This enables use cases where USB I/O must be delegated to platform-specific code
+    /// (e.g., Android, where USB access requires Java APIs unavailable to `hidapi`).
+    pub async fn from_transport(
+        transport: Box<dyn communication::ReadWrite>,
+        noise_config: Box<dyn NoiseConfig>,
+    ) -> Result<BitBox<R>, Error> {
+        let comm = Box::new(communication::U2fHidCommunication::from(
+            transport,
+            communication::FIRMWARE_CMD,
+        ));
+        Self::from(comm, noise_config).await
+    }
+
     /// Creates a new BitBox instance. The provided noise config determines how the pairing
     /// information is persisted. Use `usb::get_any_bitbox02()` to find a BitBox02 HID device.
     ///
@@ -96,11 +116,7 @@ impl<R: Runtime> BitBox<R> {
         device: hidapi::HidDevice,
         noise_config: Box<dyn NoiseConfig>,
     ) -> Result<BitBox<R>, Error> {
-        let comm = Box::new(communication::U2fHidCommunication::from(
-            Box::new(crate::usb::HidDevice::new(device)),
-            communication::FIRMWARE_CMD,
-        ));
-        Self::from(comm, noise_config).await
+        Self::from_transport(Box::new(crate::usb::HidDevice::new(device)), noise_config).await
     }
 
     #[cfg(feature = "simulator")]
@@ -108,11 +124,11 @@ impl<R: Runtime> BitBox<R> {
         endpoint: Option<&str>,
         noise_config: Box<dyn NoiseConfig>,
     ) -> Result<BitBox<R>, Error> {
-        let comm = Box::new(communication::U2fHidCommunication::from(
+        Self::from_transport(
             crate::simulator::try_connect::<R>(endpoint).await?,
-            communication::FIRMWARE_CMD,
-        ));
-        Self::from(comm, noise_config).await
+            noise_config,
+        )
+        .await
     }
 
     /// Invokes the device unlock and pairing.


### PR DESCRIPTION
## Summary

Adds a public `BitBox::from_transport()` constructor that accepts any `communication::ReadWrite` implementation and performs the U2F-HID framing internally. This lets callers delegate raw USB I/O to platform-specific code, instead of relying on `hidapi`.

Two small changes:

- Make the `communication` module public, exposing the `ReadWrite` trait and `Error`.
- Remove the feature gate on `FIRMWARE_CMD` so `from_transport` (available without the `usb`/`wasm`/`simulator` features) can perform the framing.

## Motivation

We want to drive a BitBox02 from **Android**, where USB access must go through the Java `UsbManager` API and `hidapi` is not available. The existing constructors (`from_hid_device`, `usb::get_any_bitbox02`) all assume `hidapi`, so there is currently no way to connect on such platforms.

With `from_transport()`, a caller implements only the `ReadWrite` trait over their platform's transport (on Android, a channel bridged to the Java USB stack) and gets a fully functional `BitBox` — the U2F-HID framing is handled by the library, exactly as it is for the USB path. Desktop/`hidapi` callers are unaffected.

This mirrors how the official BitBoxApp already drives the device on Android: its `GoViewModel.java` opens the device through `UsbManager`/`UsbDeviceConnection`, performs the `bulkTransfer()` I/O in Java, and hands a `ReadWriteCloser` to the Go backend (no `hidapi` on Android). `from_transport()` is simply the Rust/`bitbox-api` equivalent of that pattern.

## What changed

- `src/lib.rs`: new `pub async fn from_transport(transport: Box<dyn communication::ReadWrite>, noise_config: Box<dyn NoiseConfig>) -> Result<BitBox<R>, Error>`; `mod communication` → `pub mod communication`.
- `src/communication.rs`: `FIRMWARE_CMD` is no longer gated behind `usb`/`wasm`/`simulator`, since `from_transport` needs it without those features.

No existing API changes; this is purely additive.

## Testing

- Builds with and without the `usb` feature.
- Downstream: an Android app connects to and signs with a physical BitBox02 through a channel-based `ReadWrite` transport built on `from_transport()` — pairing, xpub export, wallet/policy registration, and PSBT signing (singlesig + multisig) all verified on-device.
